### PR TITLE
feat(s3): add HTTP transport tuning options

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -6,6 +6,7 @@ package s3
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/url"
 	"os"
 	"runtime"
@@ -34,8 +35,58 @@ type Client struct {
 	downloader *s3manager.Downloader
 }
 
+// Option configures the underlying HTTP transport of an S3 Client. Options only
+// take effect when passed to New or NewWithConfig; if none are supplied the client
+// keeps the AWS SDK's default HTTP transport untouched.
+type Option func(*options)
+
+// options accumulates the transport tuning requested via Option values.
+type options struct {
+	transport *http.Transport
+}
+
+// transportOrDefault lazily clones the default transport so that only the fields the
+// caller explicitly tunes diverge from the SDK defaults.
+func (o *options) transportOrDefault() *http.Transport {
+	if o.transport == nil {
+		o.transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+	return o.transport
+}
+
+// WithMaxIdleConnsPerHost sets the maximum number of idle (keep-alive) connections
+// to keep per host. The Go default is 2, which causes connection churn when a shared
+// client issues concurrent requests to the same bucket.
+func WithMaxIdleConnsPerHost(n int) Option {
+	return func(o *options) {
+		o.transportOrDefault().MaxIdleConnsPerHost = n
+	}
+}
+
+// WithIdleConnTimeout sets how long an idle connection is kept open before it is
+// closed. The default is 90s; a longer value lets connections survive between
+// infrequent polls.
+func WithIdleConnTimeout(d time.Duration) Option {
+	return func(o *options) {
+		o.transportOrDefault().IdleConnTimeout = d
+	}
+}
+
+// applyOptions evaluates the options and, if any transport tuning was requested,
+// attaches the customised HTTP client to the supplied config.
+func applyOptions(conf *aws.Config, opts ...Option) *aws.Config {
+	o := new(options)
+	for _, opt := range opts {
+		opt(o)
+	}
+	if o.transport != nil {
+		conf = conf.WithHTTPClient(&http.Client{Transport: o.transport})
+	}
+	return conf
+}
+
 // New a new S3 Client.
-func New(region string, retries int) (*Client, error) {
+func New(region string, retries int, opts ...Option) (*Client, error) {
 	conf := aws.NewConfig().WithMaxRetries(retries)
 
 	// Set the region or endpoint (for testing)
@@ -54,6 +105,8 @@ func New(region string, retries int) (*Client, error) {
 		conf = conf.WithRegion("us-east-1")
 	}
 
+	conf = applyOptions(conf, opts...)
+
 	// Create the session
 	sess, err := session.NewSession(conf)
 	if err != nil {
@@ -64,7 +117,9 @@ func New(region string, retries int) (*Client, error) {
 }
 
 // NewWithConfig creates new S3 Client with passed config
-func NewWithConfig(config *aws.Config) (*Client, error) {
+func NewWithConfig(config *aws.Config, opts ...Option) (*Client, error) {
+	config = applyOptions(config, opts...)
+
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,6 +40,55 @@ func TestS3(t *testing.T) {
 	val, err := cli.DownloadIf(context.Background(), "s3://bucket/hello.txt", time.Unix(0, 0))
 	assert.NoError(t, err)
 	assert.Equal(t, inputVal, val)
+}
+
+func TestNewWithConfig(t *testing.T) {
+	conf := aws.NewConfig().WithRegion("eu-west-1").WithMaxRetries(3)
+	cli, err := NewWithConfig(conf)
+	assert.NotNil(t, cli)
+	assert.NoError(t, err)
+}
+
+func TestNewWithConfigAndOptions(t *testing.T) {
+	conf := aws.NewConfig().WithRegion("eu-west-1")
+	cli, err := NewWithConfig(conf, WithMaxIdleConnsPerHost(100))
+	assert.NotNil(t, cli)
+	assert.NoError(t, err)
+	assert.NotNil(t, conf.HTTPClient)
+}
+
+func TestWithMaxIdleConnsPerHostOption(t *testing.T) {
+	o := new(options)
+	WithMaxIdleConnsPerHost(42)(o)
+	assert.NotNil(t, o.transport)
+	assert.Equal(t, 42, o.transport.MaxIdleConnsPerHost)
+}
+
+func TestWithIdleConnTimeoutOption(t *testing.T) {
+	o := new(options)
+	WithIdleConnTimeout(5 * time.Minute)(o)
+	assert.NotNil(t, o.transport)
+	assert.Equal(t, 5*time.Minute, o.transport.IdleConnTimeout)
+}
+
+func TestApplyOptionsCombines(t *testing.T) {
+	conf := aws.NewConfig()
+	conf = applyOptions(conf,
+		WithMaxIdleConnsPerHost(50),
+		WithIdleConnTimeout(2*time.Minute),
+	)
+
+	assert.NotNil(t, conf.HTTPClient)
+	tr, ok := conf.HTTPClient.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.Equal(t, 50, tr.MaxIdleConnsPerHost)
+	assert.Equal(t, 2*time.Minute, tr.IdleConnTimeout)
+}
+
+func TestApplyOptionsNoneKeepsDefaults(t *testing.T) {
+	conf := aws.NewConfig()
+	conf = applyOptions(conf)
+	assert.Nil(t, conf.HTTPClient)
 }
 
 // fakeS3 represents a fake s3 server


### PR DESCRIPTION
## Summary

Adds an `Option` mechanism to the `s3` client so callers can tune the underlying HTTP transport without replacing it wholesale.

- `WithMaxIdleConnsPerHost(n)` — sets the max idle keep-alive connections per host. Go's default of 2 causes connection churn when a shared client issues concurrent requests to the same bucket.
- `WithIdleConnTimeout(d)` — sets how long idle connections are kept open.

Options are wired into both `New` and `NewWithConfig` and are purely additive (variadic):

- When **no** options are supplied, the AWS SDK's default HTTP transport is left untouched, so existing callers are unaffected (covered by `TestApplyOptionsNoneKeepsDefaults`).
- The default transport is cloned lazily, so only the fields a caller explicitly tunes diverge from SDK defaults.

## Test plan

- `go build ./...`, `go vet ./...`
- `go test -race ./s3/` — passes (71.4% coverage)
- New tests: `TestNewWithConfig`, `TestNewWithConfigAndOptions`, `TestWithMaxIdleConnsPerHostOption`, `TestWithIdleConnTimeoutOption`, `TestApplyOptionsCombines`, `TestApplyOptionsNoneKeepsDefaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)